### PR TITLE
fix selected index k out of range

### DIFF
--- a/native_sparse_attention_pytorch/native_sparse_attention.py
+++ b/native_sparse_attention_pytorch/native_sparse_attention.py
@@ -675,6 +675,8 @@ class SparseAttention(Module):
         fk = k
         fv = v
 
+        num_selected = min(num_selected, importance_scores.shape[-1] - 1)
+        
         if has_selected_kv_for_fine_attn:
 
             # get the top-n kv segments for fine attention


### PR DESCRIPTION
if the number of blocks available for fine attention is less than the number to select with topk, there will be an error: RuntimeError: selected index k out of range

```
embedding_dim: int = 1024
head_dim: int = 64
num_attention_heads: int = 16
num_key_value_heads: int = 8
sliding_window_size: int = 512
compress_block_size: int = 32
selection_block_size: int = 64
num_selected_blocks: int = 16
nsa_causal: bool = True
nsa_use_triton_kernel: bool = False

self_attn = SparseAttention(
    dim = embedding_dim,
    dim_head = head_dim,
    heads = num_attention_heads,
    sliding_window_size = sliding_window_size,
    compress_block_size = compress_block_size,
    selection_block_size = selection_block_size,
    num_selected_blocks = num_selected_blocks,
    kv_heads=num_key_value_heads,
    causal=nsa_causal,
    use_triton_kernel=nsa_use_triton_kernel
)

tokens = torch.randn(1, 100, 1024)

attended = self_attn(tokens)

assert tokens.shape == attended.shape
```

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[10], [line 16](vscode-notebook-cell:?execution_count=10&line=16)
      [1](vscode-notebook-cell:?execution_count=10&line=1) self_attn = SparseAttention(
      [2](vscode-notebook-cell:?execution_count=10&line=2)     dim = embedding_dim,
      [3](vscode-notebook-cell:?execution_count=10&line=3)     dim_head = head_dim,
   (...)
     [11](vscode-notebook-cell:?execution_count=10&line=11)     use_triton_kernel=nsa_use_triton_kernel
     [12](vscode-notebook-cell:?execution_count=10&line=12) )
     [14](vscode-notebook-cell:?execution_count=10&line=14) tokens = torch.randn(1, 100, 1024)
---> [16](vscode-notebook-cell:?execution_count=10&line=16) attended = self_attn(tokens)
     [18](vscode-notebook-cell:?execution_count=10&line=18) assert tokens.shape == attended.shape

File ~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1739, in Module._wrapped_call_impl(self, *args, **kwargs)
   [1737](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1737)     return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   [1738](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1738) else:
-> [1739](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1739)     return self._call_impl(*args, **kwargs)

File ~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1750, in Module._call_impl(self, *args, **kwargs)
   [1745](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1745) # If we don't have any hooks, we want to skip the rest of the logic in
   [1746](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1746) # this function, and just call forward.
   [1747](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1747) if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
   [1748](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1748)         or _global_backward_pre_hooks or _global_backward_hooks
   [1749](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1749)         or _global_forward_hooks or _global_forward_pre_hooks):
-> [1750](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1750)     return forward_call(*args, **kwargs)
   [1752](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1752) result = None
   [1753](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/torch/nn/modules/module.py:1753) called_always_called_hooks = set()

File ~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:682, in SparseAttention.forward(self, inp, cache, disable_triton_kernel, sliding_window_flex_mask, fine_selection_flex_mask, return_cache)
    [676](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:676) fv = v
    [678](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:678) if has_selected_kv_for_fine_attn:
    [679](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:679) 
    [680](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:680)     # get the top-n kv segments for fine attention
--> [682](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:682)     selected_importance_values, selected_block_indices = importance_scores.topk(num_selected, dim = -1)
    [684](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:684)     gates = None
    [686](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2248383030227d.vscode-resource.vscode-cdn.net/home/model/models/test/~/.pyenv/versions/3.12.3/envs/jax/lib/python3.12/site-packages/native_sparse_attention_pytorch/native_sparse_attention.py:686)     if self.use_diff_topk:

RuntimeError: selected index k out of range
```