### PR TITLE
Small change so token embeddings aren't looked up for past tokens during inference

### DIFF
--- a/native_sparse_attention_pytorch/transformer.py
+++ b/native_sparse_attention_pytorch/transformer.py
@@ -273,7 +273,10 @@ class Transformer(Module):
 
         # token embedding
 
-        tokens = self.token_emb(ids)
+        if is_inferencing:
+            tokens = self.token_emb(ids[:, -1:])
+        else:
+            tokens = self.token_emb(ids)
 
         # prepare maybe flex attention masks
 
@@ -297,9 +300,6 @@ class Transformer(Module):
         iter_cache = iter(cache)
 
         next_cache = []
-
-        if is_inferencing:
-            tokens = tokens[:, -1:]
 
         # layers
 


### PR DESCRIPTION
Right now, the token embedding is done on all tokens in the context during generation and then the last token embedding is used. This change just makes it so during inference the last token is sent to the embedding so that it only has to be lookup up for the last token.